### PR TITLE
Add support for GCP_OAUTH2_REFRESH_TOKEN env variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,85 @@
-Docker-registry
-===============
+# Docker-registry
 
 Sources for [google/docker-registry](https://index.docker.io/u/google/docker-registry/), [Docker Registry](https://github.com/dotcloud/docker-registry) image to push/pull your [Docker](https://www.docker.io/) images to/from [Google Cloud Storage](https://cloud.google.com/products/cloud-storage/).
 
 - Uses 'gcs' as a storage option
 - Has OAuth2 support built in
-- Works locally and on [Google Compute Engine] (https://cloud.google.com/products/compute-engine/)
+- Works locally and on [Google Compute Engine](https://cloud.google.com/products/compute-engine/)
 
-
-### Building google/docker-registry image
-
-
-    docker build -t google/docker-registry .
-
-
-### Usage
+## Usage
 
 After [google/docker-registry](https://index.docker.io/u/google/docker-registry) is built or pulled from the [public registry]( https://index.docker.io/u/google/docker-registry) you can push/pull docker images to/from your [Google Cloud Storage](https://cloud.google.com/products/cloud-storage/) bucket.
 
-#### Locally
+### Specifying the bucket
 
-1. Start the registry and mount your credentials from a data container named gcloud-config. You also need to pass some environment variables to your container, i.e. GCS_BUCKET and BOTO_PATH (path to your .boto file with credentials). If you have logged in with [gcloud container](https://index.docker.io/u/google/cloud-sdk/), your credentials are in /.config/gcloud/legacy_credentials/{your email}/.boto. For more information about getting OAuth2 credentials please refer to [google/cloud-sdk](https://index.docker.io/u/google/cloud-sdk/) documentation.
+You need to specify the GCS bucket to store your images in.  To do that, set the `GCS_BUCKET` environment variable when running the Docker container.
 
+```
+docker run -d -e GCS_BUCKET=your-bucket -p 5000:5000 google/docker-registry
+```
 
+### Credentials
 
-        docker run -d -e GCS_BUCKET=yet-another-docker-bucket -p 5000:5000 \
-        --volumes-from gcloud-config google/docker-registry
+There are three ways to specify the credentials:
 
+1. Specify the Google Cloud Platform OAuth refresh token directly in an environment variable.  It is best to put this in an `--env-file` so it can't be seen with `ps` when not running detached.  Example:
 
+  ```
+  $ cat registry-params.env
+  GCP_OAUTH2_REFRESH_TOKEN=refresh-token
+  GCS_BUCKET=your-bucket
+  $ docker run -d --env-file=registry-params.env -p 5000:5000 google/docker-registry
+  ```
 
-1. Now you can store your images on GCS!
+1.  A `.boto` file in the `/.config` directory in the `docker-registry` container. The easiest way to do this is to use the `google/cloud-sdk` Docker image to create these credentials, and import its `/.config` volume using `--volumes-from`.
 
+  ```
+  $ docker run -ti --name gcloud-config google/cloud-sdk gcloud auth login
+  Go to the following link in your browser:
 
-        docker tag myawesomeimage localhost:5000/myawesomeimage
-        docker push localhost:5000/myawesomeimage
+      https://accounts.google.com/o/oauth2/auth [snip]
 
+  Enter verification code: [snip]
 
-#### Google Compute Engine
+  You are now logged in as [you@gmail.com].
+  Your current project is [None].  You can change this setting by running:
+    $ gcloud config set project <project>
 
-On [Google Compute Engine] (https://cloud.google.com/products/compute-engine/) instance you don't need to mount any volumes or pass BOTO_PATH. All necessary information will be received from Metadata Server:
+  $ docker run -ti --volumes-from gcloud-config google/cloud-sdk \
+      gcloud config set project <project>
 
-    docker run -d -e GCS_BUCKET=yet-another-docker-bucket -p 5000:5000 google/docker-registry 
+  $ docker run -d -e GCS_BUCKET=your-bucket -p 5000:5000 \
+      --volumes-from gcloud-config google/docker-registry
+  ```
 
+1. Run on [Google Compute Engine](https://cloud.google.com/products/compute-engine/) with a properly configured service account:
 
-### Notes
+  ```
+  $ gcutil addinstance --zone=us-central1-a --machine_type=f1-micro \
+      --image=projects/google-containers/global/images/container-vm-v20140522 \
+      --service_account_scopes=storage-rw \
+      my-docker-vm
+
+  [snip]
+
+  $ gcutil ssh my-docker-vm
+  $ sudo docker run -d -e GCS_BUCKET=your-bucket -p 5000:5000 google/docker-registry
+  ```
+
+### Using the registry
+
+```
+docker tag myawesomeimage localhost:5000/myawesomeimage
+docker push localhost:5000/myawesomeimage
+```
+
+## Building google/docker-registry image
+
+```
+docker build -t google/docker-registry .
+```
+
+## Notes
 
 Current image size: 257.4 MB
 

--- a/run.sh
+++ b/run.sh
@@ -6,12 +6,54 @@ GUNICORN_GRACEFUL_TIMEOUT=${GUNICORN_GRACEFUL_TIMEOUT:-3600}
 GUNICORN_SILENT_TIMEOUT=${GUNICORN_SILENT_TIMEOUT:-3600}
 
 USAGE="docker run -e GCS_BUCKET=yet-another-docker-bucket \
-[-e BOTO_PATH='/.config/gcloud/legacy_credentials/<YOUR_EMAIL>/.boto'] -p 5000:5000 \
---volumes-from gcloud-config google/docker-registry"
+[-e BOTO_PATH='/.config/gcloud/legacy_credentials/<YOUR_EMAIL>/.boto'] \
+[-e GCP_OAUTH2_REFRESH_TOKEN=<refresh token>] \
+-p 5000:5000 \
+[--volumes-from gcloud-config] google/docker-registry"
 
-GCS_BUCKET=${GCS_BUCKET:?"bucket not defined: ${USAGE}"}
-BOTO_PATH=${BOTO_PATH:-$(find /.config | grep .boto | head -n 1)}
-wget -qO- http://metadata.google.internal || BOTO_PATH=${BOTO_PATH:?"boto credentials not found: ${USAGE}"}
+if [[ -z GCS_BUCKET ]]; then
+  echo "GCS_BUCKET not defined"
+  echo
+  echo "$USAGE"
+  exit 1
+fi
+
+# If a refresh token is passed in directly, use that.
+if [[ -n "$GCP_OAUTH2_REFRESH_TOKEN" ]]; then
+  cat >/etc/boto.cfg <<EOF
+[Credentials]
+gs_oauth2_refresh_token = $GCP_OAUTH2_REFRESH_TOKEN
+EOF
+  BOTO_PATH=/etc/boto.cfg
+  echo "Using credentails specified in GCP_OAUTH2_REFRESH_TOKEN env variable"
+fi
+
+# Look to see if something is mounted under the /.config dir
+if [[ -z "${BOTO_PATH}" ]]; then
+  BOTO_PATH=${BOTO_PATH:-$(find /.config | grep .boto | head -n 1)}
+fi
+
+if [[ -n "${BOTO_PATH}" ]]; then
+  echo "Using credentials in ${BOTO_PATH}"
+else
+  wget -q --header='Metadata-Flavor: Google' \
+    http://metadata.google.internal./computeMetadata/v1/instance/service-accounts/default/scopes \
+    -O - | grep devstorage > /dev/null
+  GCE_SA=$?
+
+  if [[ $GCE_SA -eq 0 ]]; then
+    echo "Using credentials from GCE Service Account"
+  else
+    echo "Boto credentials not found.  Either:"
+    echo " - Set GCP_OAUTH2_REFRESH_TOKEN"
+    echo " - Mount credentials under /.config in the container"
+    echo " - Run in GCE with a service account configured for access"
+    echo
+    echo "$USAGE"
+    exit 1
+  fi
+fi
+
 export GCS_BUCKET BOTO_PATH
 
 cd "$(dirname $0)"


### PR DESCRIPTION
This addresses #8.

Also:
- Be more robust about detecting GCE service account scopes. (#5)
- Clarify different auth methods in README.md
