### PR TITLE
Upgrade gevent to 1.0.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update || true
 apt-get install -y --no-install-recommends \
-    git-core python-gevent gcc python-dev \
+    git-core gcc python-dev \
     gunicorn python-boto liblzma-dev \
     python-yaml python-lzma python-crypto python-requests \
     python-simplejson python-redis python-openssl wget python-pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+gevent==1.0.1
 backports.lzma==0.0.2
 blinker==1.3
 Flask==0.9


### PR DESCRIPTION
Upgrade to a post-1.0 version of gevent so we can avoid strange DNS behavior in the 'monkey-patched' httplib2 library.

NOTE: this also makes the FQDN used for "metadata.google.internal" consistent with the way its specified in other tooling (e.g. gcloud, gcutil, gsutil, gcs boto plugin, java's ComputeCredential)
