### PR TITLE
Dockerfile: optimize caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM google/debian:wheezy
 
-ADD . /docker-registry
-
+ADD requirements.txt /docker-registry/requirements.txt
+ADD build.sh /docker-registry/build.sh
 RUN /docker-registry/build.sh
+ADD . /docker-registry
+RUN ln -s /docker-registry/config.yml /docker-registry/config/config.yml
 
 # This is the default port that docker-registry is listening on.
 # Needs to be set into 5000 or the value of REGISTRY_PORT environment variable

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,6 @@ rm /var/lib/apt/lists/*_*
 apt-get clean
 
 (cd /docker-registry && pip install -r requirements.txt)
+
 apt-get purge -y --force-yes gcc python-dev git-core
 apt-get autoremove -y --force-yes
-
-mv /docker-registry/config.yml /docker-registry/config/config.yml


### PR DESCRIPTION
Optimize caching by only adding the file necessary for `build.sh`
