### PR TITLE
run.sh: add support for GCP_ACCOUNT

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There are three ways to specify the credentials:
         GCS_BUCKET=your-bucket
         $ docker run -d --env-file=registry-params.env -p 5000:5000 google/docker-registry
 
-1.  A `.boto` file in the `/.config` directory in the `docker-registry` container. The easiest way to do this is to use the `google/cloud-sdk` Docker image to create these credentials, and import its `/.config` volume using `--volumes-from`.
+1. A `.boto` file in the `/.config` directory in the `docker-registry` container. The easiest way to do this is to use the `google/cloud-sdk` Docker image to create these credentials, and import its `/.config` volume using `--volumes-from`.
 
         $ docker run -ti --name gcloud-config google/cloud-sdk gcloud auth login
         Go to the following link in your browser:
@@ -48,6 +48,11 @@ There are three ways to specify the credentials:
             gcloud config set project <project>
 
         $ docker run -d -e GCS_BUCKET=your-bucket -p 5000:5000 \
+            --volumes-from gcloud-config google/docker-registry
+
+   You can optionally set `GCP_ACCOUNT` if you want to select a different user than the default one:
+
+        $ docker run -d -e GCS_BUCKET=your-bucket GCP_ACCOUNT=your-secondary-email -p 5000:5000 \
             --volumes-from gcloud-config google/docker-registry
 
 1. Run on [Google Compute Engine](https://cloud.google.com/products/compute-engine/) with a properly configured service account:

--- a/run.sh
+++ b/run.sh
@@ -6,6 +6,7 @@ GUNICORN_GRACEFUL_TIMEOUT=${GUNICORN_GRACEFUL_TIMEOUT:-3600}
 GUNICORN_SILENT_TIMEOUT=${GUNICORN_SILENT_TIMEOUT:-3600}
 
 USAGE="docker run -e GCS_BUCKET=yet-another-docker-bucket \
+[-e GCP_ACCOUNT='<YOUR_EMAIL>' ] \
 [-e BOTO_PATH='/.config/gcloud/legacy_credentials/<YOUR_EMAIL>/.boto'] \
 [-e GCP_OAUTH2_REFRESH_TOKEN=<refresh token>] \
 -p 5000:5000 \
@@ -30,12 +31,14 @@ fi
 
 # Look to see if something is mounted under the /.config dir
 if [[ -z "${BOTO_PATH}" ]]; then
-  BOTO_PATH=${BOTO_PATH:-$(find /.config | grep .boto | head -n 1)}
+  GCP_ACCOUNT=${GCP_ACCOUNT:-$(echo $(grep account /.config/gcloud/properties | cut -d = -f 2))}
+  BOTO_PATH=${BOTO_PATH:-$(find /.config/gcloud/legacy_credentials/$GCP_ACCOUNT/.boto)}
 fi
 
 if [[ -n "${BOTO_PATH}" ]]; then
   echo "Using credentials in ${BOTO_PATH}"
 else
+  # fallback on GCE auth
   wget -q --header='Metadata-Flavor: Google' \
     http://metadata.google.internal./computeMetadata/v1/instance/service-accounts/default/scopes \
     -O - | grep devstorage > /dev/null
@@ -46,8 +49,9 @@ else
   else
     echo "Boto credentials not found.  Either:"
     echo " - Set GCP_OAUTH2_REFRESH_TOKEN"
-    echo " - Mount credentials under /.config in the container"
-    echo " - Run in GCE with a service account configured for access"
+    echo " - Set BOTO_PATH"
+    echo " - Mount gcloud credentials under /.config in the container and optionally set GCP_ACCOUNT"
+    echo " - Run in GCE with a service account configured for devstorage access"
     echo
     echo "$USAGE"
     exit 1


### PR DESCRIPTION
Fixes #7 

/cc @jbeda @ktintc @dlorenc 
### Tests
#### Without GCP_ACCOUNT

```
$ docker run -e GCS_BUCKET=proppy-containers --volumes-from gcloud-config proppy/docker-registry bash -c "cd /docker-registry && ./setup-configs.sh && exec bash ./run.sh"
Using credentials in /.config/gcloud/legacy_credentials/proppy@google.com/.boto
```
#### With GCP_ACCOUNT

```
$ docker run -e GCS_BUCKET=proppy-containers -e GCP_ACCOUNT=proppy@google.com --volumes-from gcloud-config proppy/docker-registry bash -c "cd /docker-registry && ./setup-configs.sh && exec bash ./run.sh"
Using credentials in /.config/gcloud/legacy_credentials/proppy@google.com/.boto
```
#### Error

```
$ docker run -e GCS_BUCKET=proppy-containers -e GCP_ACCOUNT=foo --volumes-from gcloud-config proppy/docker-registry bash -c "cd /docker-registry && ./setup-configs.sh && exec bash ./run.sh"
find: `/.config/gcloud/legacy_credentials/foo/.boto': No such file or directory
Boto credentials not found.  Either:
 - Set GCP_OAUTH2_REFRESH_TOKEN
 - Set BOTO_PATH
 - Mount gcloud credentials under /.config in the container and optionally set GCP_ACCOUNT
 - Run in GCE with a service account configured for devstorage access

docker run -e GCS_BUCKET=yet-another-docker-bucket [-e GCP_ACCOUNT='<YOUR_EMAIL>' ] [-e BOTO_PATH='/.config/gcloud/legacy_credentials/<YOUR_EMAIL>/.boto'] [-e GCP_OAUTH2_REFRESH_TOKEN=<refresh token>] -p 5000:5000 [--volumes-from gcloud-config] google/docker-registry
```
