### PR TITLE
Update upstream docker/docker-registry repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM google/debian:wheezy
 
-RUN apt-get update && apt-get install --no-install-recommends -yq python-pip build-essential python-dev liblzma-dev libffi-dev curl openssl
+RUN apt-get update \
+    && apt-get install --no-install-recommends -yq python-pip build-essential python-dev liblzma-dev libffi-dev curl openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN pip install docker-registry==0.9
 
 ADD requirements.txt /docker-registry-gcs-plugin/requirements.txt
@@ -8,6 +10,10 @@ RUN pip install -r  /docker-registry-gcs-plugin/requirements.txt
 ADD setup.py /docker-registry-gcs-plugin/setup.py
 ADD docker_registry /docker-registry-gcs-plugin/docker_registry
 RUN pip install /docker-registry-gcs-plugin
+
+# Vendor patch to address #22 - can be removed once docker-registry==1.0 lands.
+RUN cd /usr/local/lib/python2.7/dist-packages \
+    && curl -s https://github.com/docker/docker-registry/commit/3962264535907231670d9ff74d1c7f3ec7f8bf87.diff | patch -p1
 
 ENV DOCKER_REGISTRY_CONFIG /docker-registry/config/config.yml
 ADD config.yml /docker-registry/config/


### PR DESCRIPTION
Updates to 0.9 + the merge of the patch that addresses #22 

@proppy can I convince you to upgrade the upstream package to address the linear scan issue?  We'd rather pull from the official google docker images rather than baking our own.  The patch that fixes #22 was just accepted in docker/docker-repository today as the first commit after the 0.9 release.
